### PR TITLE
Comments for directories

### DIFF
--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -167,7 +167,11 @@ var underscore = _.noConflict();
 		},
 		render: function() {
 			this.$el.html(this.template({formatting_help_url: CodeComments.formatting_help_url}))
-				.dialog({ autoOpen: false, title: 'Add Comment', close: this.close });
+				.dialog({ autoOpen: false, title: 'Add Comment', close: this.close, modal: true });
+			// Prevent keypresses in the dialog from being intercepted by other scripts
+			this.$el.keydown(function(e) {
+				event.stopPropagation();
+			});
 			this.$('button.add-comment').button();
 			return this;
 		},

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -168,7 +168,10 @@ var underscore = _.noConflict();
 		render: function() {
 			this.$el.html(this.template({formatting_help_url: CodeComments.formatting_help_url}))
 				.dialog({ autoOpen: false, title: 'Add Comment', close: this.close, modal: true });
-			// Prevent keypresses in the dialog from being intercepted by other scripts
+			// As the textarea in our dialog is created after Trac's
+			// keyboard_nav.js has bound, we have to stop keydown events
+			// propoagating in order to avoid unexpected navigation while the
+			// user is typing their comment.
 			this.$el.keydown(function(e) {
 				event.stopPropagation();
 			});

--- a/code_comments/web.py
+++ b/code_comments/web.py
@@ -109,7 +109,7 @@ class JSDataForRequests(CodeComments):
         return {'page': 'changeset', 'revision': data['new_rev'], 'path': '', 'selectorToInsertBefore': 'div.diff:first'}
 
     def browser_js_data(self, req, data):
-        return {'page': 'browser', 'revision': data['rev'], 'path': data['path'], 'selectorToInsertBefore': 'table#info'}
+        return {'page': 'browser', 'revision': data['rev'], 'path': data['path'], 'selectorToInsertBefore': 'table#info, table#dirlist'}
 
     def attachment_js_data(self, req, data):
         path = req.path_info.replace('/attachment/', 'attachment:/')


### PR DESCRIPTION
Fixes #39 by using multiple selectors to correctly show the top comments for both files and directories, and stops key presses propagating when the dialog is shown to prevent Tracs keyboard navigation from intercepting them.
