### PR TITLE
Multiple repository support

### DIFF
--- a/code_comments/comment.py
+++ b/code_comments/comment.py
@@ -70,9 +70,9 @@ class Comment:
 
     def href(self):
         if self.is_comment_to_file:
-            href = self.req.href.browser(self.path, rev=self.revision, codecomment=self.id)
+            href = self.req.href.browser(self.reponame + '/' + self.path, rev=self.revision, codecomment=self.id)
         elif self.is_comment_to_changeset:
-            href = self.req.href.changeset(self.revision, codecomment=self.id)
+            href = self.req.href.changeset(self.revision + '/' + self.reponame, codecomment=self.id)
         elif self.is_comment_to_attachment:
             href = self.req.href('/attachment/ticket/%d/%s' % (self.attachment_ticket, self.attachment_filename), codecomment=self.id)
         if self.line and not self.is_comment_to_changeset:

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -196,6 +196,7 @@ var underscore = _.noConflict();
 				title += ( displayLine ? 'line ' + displayLine + ' of ' : '' )
 				      + this.path + '@' + CodeComments.revision;
 			}
+			title += ' in ' + CodeComments.reponame;
 			return title;
 		},
 		close: function() {
@@ -213,7 +214,7 @@ var underscore = _.noConflict();
 				},
 				wait: true
 			};
-			this.collection.create({text: text, author: CodeComments.username, path: this.path, revision: CodeComments.revision, line: line, type: CodeComments.page}, options);
+			this.collection.create({text: text, author: CodeComments.username, path: this.path, reponame: CodeComments.reponame, revision: CodeComments.revision, line: line, type: CodeComments.page}, options);
 		},
 		previewThrottled: $.throttle(1500, function(e) { return this.preview(e); }),
 		preview: function(e) {

--- a/code_comments/subscription.py
+++ b/code_comments/subscription.py
@@ -245,7 +245,7 @@ class Subscription(object):
                 sub['path'] = comment.path
             else:
                 sub['path'] = ''
-            repo = RepositoryManager(env).get_repository(None)
+            repo = RepositoryManager(env).get_repository(comment.reponame)
             try:
                 sub['repos'] = repo.reponame
                 try:

--- a/code_comments/web.py
+++ b/code_comments/web.py
@@ -106,14 +106,14 @@ class JSDataForRequests(CodeComments):
         return data
 
     def changeset_js_data(self, req, data):
-        return {'page': 'changeset', 'revision': data['new_rev'], 'path': '', 'selectorToInsertAfter': 'div.diff div.diff:last'}
+        return {'page': 'changeset', 'reponame': data['reponame'], 'revision': data['new_rev'], 'path': '', 'selectorToInsertAfter': 'div.diff div.diff:last'}
 
     def browser_js_data(self, req, data):
-        return {'page': 'browser', 'revision': data['rev'], 'path': data['path'], 'selectorToInsertAfter': 'table.code'}
+        return {'page': 'browser', 'reponame': data['reponame'], 'revision': data['rev'], 'path': data['path'], 'selectorToInsertAfter': 'table.code'}
 
     def attachment_js_data(self, req, data):
         path = req.path_info.replace('/attachment/', 'attachment:/')
-        return {'page': 'attachment', 'revision': 0, 'path': path, 'selectorToInsertAfter': 'div#preview'}
+        return {'page': 'attachment', 'reponame': '', 'revision': 0, 'path': path, 'selectorToInsertAfter': 'div#preview'}
 
     def template_js_data(self, name):
         file_name = name + '.html'


### PR DESCRIPTION
This PR makes the plugin aware of [multiple repositories in Trac](https://trac.edgewall.org/wiki/MultipleRepositorySupport). While there already was a field ```repos``` for the subscriptions, it was still missing for the comments.