### PR TITLE
Make linenumbers relative to file

### DIFF
--- a/code_comments/comment.py
+++ b/code_comments/comment.py
@@ -71,10 +71,10 @@ class Comment(object):
 
     def href(self):
         if self.is_comment_to_file:
-            href = self.req.href.browser(self.path, rev=self.revision,
+            href = self.req.href.browser(self.reponame + '/' + self.path, rev=self.revision,
                                          codecomment=self.id)
         elif self.is_comment_to_changeset:
-            href = self.req.href.changeset(self.revision, codecomment=self.id)
+            href = self.req.href.changeset(self.revision + '/' + self.reponame, codecomment=self.id)
         elif self.is_comment_to_attachment:
             href = self.req.href('/attachment/ticket/%d/%s'
                                  % (self.attachment_ticket,

--- a/code_comments/comments.py
+++ b/code_comments/comments.py
@@ -101,6 +101,9 @@ class Comments(object):
             elif name.endswith('__lt'):
                 name = name.replace('__lt', '')
                 conditions.append(name + ' < %s')
+            elif name.endswith('__ne'):
+                name = name.replace('__ne', '')
+                conditions.append(name + ' != %s')
             elif name.endswith('__prefix'):
                 values.append(
                     args[name].replace('%', '\\%').replace('_', '\\_') + '%')

--- a/code_comments/comments.py
+++ b/code_comments/comments.py
@@ -21,9 +21,14 @@ class Comments(object):
     def get_filter_values(self):
         comments = self.all()
         return {
+            'repos': self.get_all_repos(comments),
             'paths': self.get_all_paths(comments),
             'authors': self.get_all_comment_authors(comments),
         }
+
+    def get_all_repos(self, comments):
+        # Skip the empty string which is the repository for comments on attachments
+        return sorted(list(set([comment.reponame for comment in comments if comment.reponame != ''])))
 
     def get_all_paths(self, comments):
         def get_directory(path):

--- a/code_comments/comments.py
+++ b/code_comments/comments.py
@@ -13,7 +13,7 @@ class Comments(object):
 
     def __init__(self, req, env):
         self.req, self.env = req, env
-        self.valid_sorting_methods = ('id', 'author', 'time', 'path', 'text')
+        self.valid_sorting_methods = ('id', 'author', 'time', 'reponame', 'path', 'text')
 
     def comment_from_row(self, row):
         return Comment(self.req, self.env, row)

--- a/code_comments/db.py
+++ b/code_comments/db.py
@@ -4,9 +4,10 @@ from trac.core import Component, implements
 from trac.db.schema import Table, Column, Index
 from trac.env import IEnvironmentSetupParticipant
 from trac.db.api import DatabaseManager
+from trac.versioncontrol.api import RepositoryManager
 
 # Database version identifier for upgrades.
-db_version = 3
+db_version = 4
 db_version_key = 'code_comments_schema_version'
 
 # Database schema
@@ -21,8 +22,11 @@ schema = {
         Column('author'),
         Column('time', type='int'),
         Column('type'),
+        Column('reponame'),
         Index(['path']),
         Index(['author']),
+        Index(['reponame', 'path']),
+        Index(['revision', 'reponame']),
     ],
     'code_comments_subscriptions': Table('code_comments_subscriptions',
                                          key=('id', 'user', 'type', 'path',
@@ -76,9 +80,34 @@ def upgrade_from_2_to_3(env):
     dbm.create_tables((schema['code_comments_subscriptions'],))
 
 
+def upgrade_from_3_to_4(env):
+    with env.db_transaction as db:
+        # Add the new column "reponame" and indexes.
+        db('ALTER TABLE code_comments ADD COLUMN reponame text')
+        db('CREATE INDEX code_comments_reponame_path_idx ON code_comments (reponame, path)')
+        db('CREATE INDEX code_comments_revision_reponame_idx ON code_comments (revision, reponame)')
+
+        # Comments on attachments need to have the empty string as the reponame instead of NULL.
+        db("UPDATE code_comments SET reponame = '' WHERE type = 'attachment'")
+
+        # Comments on changesets have the reponame in the 'path' column.
+        db("UPDATE code_comments SET reponame = path, path = '' WHERE type = 'changeset'")
+
+        # Comments on files have the reponame as the first component of the 'path' column.
+        db("""
+            UPDATE code_comments
+            SET
+                reponame = substr(path, 1, instr(path, '/') - 1),
+                path = substr(path, instr(path, '/') + 1)
+            WHERE
+                type = 'browser'
+            """)
+
+
 upgrade_map = {
     2: upgrade_from_1_to_2,
     3: upgrade_from_2_to_3,
+    4: upgrade_from_3_to_4,
 }
 
 

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -28,6 +28,7 @@ var underscore = _.noConflict();
 		},
 		defaultFetchParams: {
 			path: CodeComments.path || undefined,
+			reponame: CodeComments.reponame,
 			revision: CodeComments.revision,
 			type: CodeComments.page,
 		},

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -115,7 +115,7 @@ var underscore = _.noConflict();
 			if (!this.viewPerLine[line]) {
 				this.viewPerLine[line] = new CommentsForALineView( { line: line } );
 
-				var $tr = $( Rows.getTrByLineNumber( line ) );
+				var $tr = $( Rows.getTrByLineNumberInDiff( line ) );
 				$tr.after(this.viewPerLine[line].render().el).addClass('with-comments');
 			}
 			this.viewPerLine[line].addOne(comment);
@@ -239,7 +239,7 @@ var underscore = _.noConflict();
 			var callbackMouseover = function( event ) {
 				var row = new RowView( { el: this } ),
 					file = row.getFile(),
-					line = row.getLineNumber(),
+					line = row.getLineNumberInDiff(),
 					displayLine = row.getDisplayLine();
 				row.replaceLineNumberCellContent( '<a title="Comment on this line" href="#L' + line + '" class="bubble"><span class="ui-icon ui-icon-comment"></span></a>' );
 
@@ -268,10 +268,10 @@ var underscore = _.noConflict();
 			// wrap TH content in spans so we can hide/show them
 			this.wrapTHsInSpans();
 		},
-		getLineByTR: function( tr ) {
+		getLineNumberInDiffByTr: function( tr ) {
 			return $.inArray( tr, this.$rows ) + 1;
 		},
-		getTrByLineNumber: function( line ) {
+		getTrByLineNumberInDiff: function( line ) {
 			return this.$rows[line - 1];
 		},
 		wrapTHsInSpans: function() {
@@ -303,8 +303,8 @@ var underscore = _.noConflict();
 		getFile: function() {
 			return this.$el.parents( 'li' ).find( 'h2>a:first' ).text();
 		},
-		getLineNumber: function() {
-			return Rows.getLineByTR( this.el );
+		getLineNumberInDiff: function() {
+			return Rows.getLineNumberInDiffByTr( this.el );
 		},
 		getDisplayLine: function() {
 			return this.$lineNumberCell.text().trim() || this.$th.first().text() + ' (deleted)';

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -218,6 +218,7 @@ var underscore = _.noConflict();
 				text: text,
 				author: CodeComments.username,
 				path: this.path,
+				reponame: CodeComments.reponame,
 				revision: CodeComments.revision,
 				line: line,
 				type: CodeComments.page

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -303,11 +303,22 @@ var underscore = _.noConflict();
 		getFile: function() {
 			return this.$el.parents( 'li' ).find( 'h2>a:first' ).text();
 		},
+		getLineNumberInFile: function() {
+			var lineNumber = this.$lineNumberCell.text().trim();
+			if (lineNumber)
+				return lineNumber;
+			else
+				return this.$th.first().text().trim() * -1;
+		},
 		getLineNumberInDiff: function() {
 			return Rows.getLineNumberInDiffByTr( this.el );
 		},
 		getDisplayLine: function() {
-			return this.$lineNumberCell.text().trim() || this.$th.first().text() + ' (deleted)';
+			var lineNumber = this.getLineNumberInFile()
+			if (lineNumber > 0)
+				return lineNumber;
+			else
+				return lineNumber * -1 + ' (deleted)';
 		}
 	} );
 

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -36,7 +36,7 @@ var underscore = _.noConflict();
 			return this.fetch( { data: _.extend( { line: 0 }, this.defaultFetchParams ) } );
 		},
 		fetchLineComments: function() {
-			return this.fetch( { data: _.extend( { line__gt: 0 }, this.defaultFetchParams ) } );
+			return this.fetch( { data: _.extend( { line__ne: 0 }, this.defaultFetchParams ) } );
 		}
 	});
 
@@ -112,13 +112,15 @@ var underscore = _.noConflict();
 		},
 		addOne: function(comment) {
 			var line = comment.get('line');
-			if (!this.viewPerLine[line]) {
-				this.viewPerLine[line] = new CommentsForALineView( { line: line } );
+			var file = comment.get('path');
+			var key = 'file_' + file + ':' + line;
+			if (!this.viewPerLine[key]) {
+				this.viewPerLine[key] = new CommentsForALineView( { file: file, line: line } );
 
-				var $tr = $( Rows.getTrByLineNumberInDiff( line ) );
-				$tr.after(this.viewPerLine[line].render().el).addClass('with-comments');
+				var $tr = $( Rows.getTrByFileAndLineNumberInFile( file, line ) );
+				$tr.after(this.viewPerLine[key].render().el).addClass('with-comments');
 			}
-			this.viewPerLine[line].addOne(comment);
+			this.viewPerLine[key].addOne(comment);
 		},
 		addAll: function() {
 			var view = this;
@@ -134,6 +136,7 @@ var underscore = _.noConflict();
 		template: _.template(CodeComments.templates.comments_for_a_line),
 		initialize: function(attrs) {
 			this.line = attrs.line;
+			this.file = attrs.file;
 		},
 		events: {
 			'click button': 'showAddCommentDialog'
@@ -239,7 +242,7 @@ var underscore = _.noConflict();
 			var callbackMouseover = function( event ) {
 				var row = new RowView( { el: this } ),
 					file = row.getFile(),
-					line = row.getLineNumberInDiff(),
+					line = row.getLineNumberInFile(),
 					displayLine = row.getDisplayLine();
 				row.replaceLineNumberCellContent( '<a title="Comment on this line" href="#L' + line + '" class="bubble"><span class="ui-icon ui-icon-comment"></span></a>' );
 
@@ -273,6 +276,34 @@ var underscore = _.noConflict();
 		},
 		getTrByLineNumberInDiff: function( line ) {
 			return this.$rows[line - 1];
+		},
+		getTrByFileAndLineNumberInFile: function ( file, line) {
+			var col;
+			var container;
+			if (CodeComments.page == "browser" && CodeComments.path == file) {
+				container = $( 'thead', 'table.code' );
+				col = 0;
+			} else {
+				if (line < 0) {
+					line = -line;
+					col = 0;
+				} else {
+					col = 1
+				}
+				var containers = $( 'thead', 'table.code, table.trac-diff' );
+				for ( var i = 0; (container = containers[i]) != null; i++ ) {
+					if ($(container).parents( 'li' ).find( 'h2>a:first' ).text() == file) {
+						break;
+					}
+				}
+			}
+			var trs = $(container).parents( 'table' ).find( 'tbody>tr' ).not('.comments');
+			for ( var i = 0, tr; (tr = trs[i]) != null; i++ ) {
+				if ($(tr).find( 'th>span' )[col].textContent == line) {
+					return tr;
+				}
+			}
+			return null;
 		},
 		wrapTHsInSpans: function() {
 			$( 'th', this.$rows ).each( function( i, elem ) {

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -271,12 +271,6 @@ var underscore = _.noConflict();
 			// wrap TH content in spans so we can hide/show them
 			this.wrapTHsInSpans();
 		},
-		getLineNumberInDiffByTr: function( tr ) {
-			return $.inArray( tr, this.$rows ) + 1;
-		},
-		getTrByLineNumberInDiff: function( line ) {
-			return this.$rows[line - 1];
-		},
 		getTrByFileAndLineNumberInFile: function ( file, line) {
 			var col;
 			var container;
@@ -340,9 +334,6 @@ var underscore = _.noConflict();
 				return lineNumber;
 			else
 				return this.$th.first().text().trim() * -1;
-		},
-		getLineNumberInDiff: function() {
-			return Rows.getLineNumberInDiffByTr( this.el );
 		},
 		getDisplayLine: function() {
 			var lineNumber = this.getLineNumberInFile()

--- a/code_comments/subscription.py
+++ b/code_comments/subscription.py
@@ -236,13 +236,13 @@ class Subscription(object):
 
         # Munge changesets and browser
         if comment.type in ('changeset', 'browser'):
-            rm = RepositoryManager(env)
-            reponame, repos, path = rm.get_repository_by_path(comment.path)
             if comment.type == 'browser':
-                sub['path'] = path
+                sub['path'] = comment.path
             else:
                 sub['path'] = ''
-            sub['repos'] = reponame or '(default)'
+            sub['repos'] = comment.reponame
+            rm = RepositoryManager(env)
+            repos = rm.get_repository(comment.reponame)
             try:
                 _cs = repos.get_changeset(comment.revision)
             except NoSuchChangeset:

--- a/code_comments/subscription.py
+++ b/code_comments/subscription.py
@@ -296,11 +296,9 @@ class Subscription(object):
             args['rev'] = str(comment.revision)
 
         if comment.type == 'browser':
-            rm = RepositoryManager(env)
-            reponame, _, path = rm.get_repository_by_path(comment.path)
             args['type'] = ('browser', 'changeset')
-            args['path'] = (path, '')
-            args['repos'] = reponame
+            args['path'] = (comment.path, '')
+            args['repos'] = comment.reponame
             args['rev'] = (str(comment.revision), '')
 
         return cls.select(env, args, notify)

--- a/code_comments/templates/comments.html
+++ b/code_comments/templates/comments.html
@@ -49,6 +49,7 @@
                     <td>$comment.id</td>
                     <th>$comment.author</th>
                     <th>${comment.formatted_date()}</th>
+                    <td>$comment.reponame</td>
                     <td>${comment.path_link_tag()}</td>
                     <td>$comment.html</td>
                     <td>${comment.get_ticket_links()}</td>

--- a/code_comments/templates/comments.html
+++ b/code_comments/templates/comments.html
@@ -15,6 +15,12 @@
         <button id="send-to-ticket" type="submit" data-url="${href('code-comments', 'create-ticket')}">Create ticket with selected</button>
         &nbsp;Filter comments:
         <form action="${href('code-comments')}" method="GET" style="display: inline;">
+            <select id="filter-by-repo" name="filter-by-repo">
+                <option value='' selected="selected">-- All repositories --</option>
+                <option py:for="repo in repos"
+                           selected="${current_repo_selection == repo or None}"
+                           value="$repo" py:content="repo"></option>
+            </select>
             <select id="filter-by-path" name="filter-by-path">
                 <option value='' selected="selected">-- All paths --</option>
                 <option py:for="path in paths"

--- a/code_comments/web.py
+++ b/code_comments/web.py
@@ -243,9 +243,9 @@ class ListComments(CodeComments):
 
     def prepare_sortable_headers(self):
         displayed_sorting_methods = \
-            ('id', 'author', 'time', 'path', 'text')
+            ('id', 'author', 'time', 'reponame', 'path', 'text')
         displayed_sorting_method_names = \
-            ('ID', 'Author', 'Date', 'Path', 'Text')
+            ('ID', 'Author', 'Date', 'Repository', 'Path', 'Text')
         query_args = self.req.args
         if 'page' in query_args:
             del query_args['page']

--- a/code_comments/web.py
+++ b/code_comments/web.py
@@ -198,9 +198,15 @@ class ListComments(CodeComments):
         return template, data, content_type
 
     def add_path_and_author_filters(self):
+        self.data['current_repo_selection'] = ''
         self.data['current_path_selection'] = ''
         self.data['current_author_selection'] = ''
 
+        if self.req.args.get('filter-by-repo'):
+            self.args['reponame'] = \
+                self.req.args['filter-by-repo']
+            self.data['current_repo_selection'] = \
+                self.req.args['filter-by-repo']
         if self.req.args.get('filter-by-path'):
             self.args['path__prefix'] = \
                 self.req.args['filter-by-path']

--- a/code_comments/web.py
+++ b/code_comments/web.py
@@ -121,16 +121,18 @@ class JSDataForRequests(CodeComments):
     def changeset_js_data(self, req, data):
         return {
             'page': 'changeset',
+            'reponame': data['reponame'],
             'revision': data['new_rev'],
-            'path': data['reponame'],
+            'path': '',
             'selectorToInsertAfter': 'div.diff div.diff:last'
         }
 
     def browser_js_data(self, req, data):
         return {
             'page': 'browser',
+            'reponame': data['reponame'],
             'revision': data['rev'],
-            'path': (data['reponame'] or '') + '/' + data['path'],
+            'path': data['path'],
             'selectorToInsertAfter': 'table.code'
         }
 
@@ -138,6 +140,7 @@ class JSDataForRequests(CodeComments):
         path = req.path_info.replace('/attachment/', 'attachment:/')
         return {
             'page': 'attachment',
+            'reponame': '',
             'revision': 0,
             'path': path,
             'selectorToInsertAfter': 'div#preview'


### PR DESCRIPTION
This fixes #67.
Comments to lines of a file are now referenced to the actual line in the file, not the line in the diff-view. If the comment is for a deleted line, the line-number  within the old file is used and saved along with a minus-sign as a flag to indicate it is for the old file.

There is room for further improvement:
* Migrate of existing comments using default values for creating the diff-view.
* Show an indicator if a comment is hidden, because the line it is on is outside the current diff-view.