### PR TITLE
Feature: Change icon for commented changesets

### DIFF
--- a/code_comments/htdocs/code-comments.css
+++ b/code_comments/htdocs/code-comments.css
@@ -130,3 +130,9 @@ button#subscribe {
 	float: right;
 	margin: 5px 0 5px 5px;
 }
+
+/* Highlight links to commented revisions */
+.chglist td.rev a.chgset.chgset-commented {
+	background-image: url(jquery-ui/images/ui-icons_4b954f_256x240.png);
+	background-position: -131px -98px;
+}

--- a/code_comments/htdocs/log-view-enhancer.js
+++ b/code_comments/htdocs/log-view-enhancer.js
@@ -1,0 +1,18 @@
+$(document).ready(function($){
+	function isLinkToCommentedRevision($link) {
+		const href = $link.attr('href');
+		const match = href && href.match(/^\/changeset\/([^/]+)\/.*$/);
+		if (!match) {
+			return false;
+		}
+		const targetRevision = match[1];
+		return CodeCommentsCommentedRevisions.includes(targetRevision);
+	}
+	const $changesetLinks = jQuery('td.rev a.chgset')
+	$changesetLinks.each(function(){
+		$link = $(this)
+		if (isLinkToCommentedRevision($link)) {
+			$link.addClass('chgset-commented');
+		}
+    });
+});

--- a/code_comments/web.py
+++ b/code_comments/web.py
@@ -351,3 +351,30 @@ class WikiPreview(CodeComments):
     def process_request(self, req):
         html = format_to_html(req, self.env, req.args.get('text', ''))
         req.send(html.encode('utf-8'))
+
+
+class HighlightCommentedRevisions(Component):
+    implements(IRequestFilter)
+
+    # IRequestFilter methods
+    def pre_process_request(self, req, handler):
+        return handler
+
+    def post_process_request(self, req, template, data, metadata):
+        if not re.match(r'^\/log\/\w+', req.path_info):
+            return template, data, metadata
+
+        query_params = {
+            'type': 'changeset',
+            'reponame': data['reponame'],
+        }
+        revisions_with_comments = []
+        for revision in data['changes']:
+            query_params['revision'] = revision
+            has_comments = bool(Comments(None, self.env).count(query_params))
+            if has_comments:
+                revisions_with_comments.append(revision)
+
+        add_script_data(req, {'CodeCommentsCommentedRevisions': revisions_with_comments})
+        add_script(req, 'code-comments/log-view-enhancer.js')
+        return template, data, metadata


### PR DESCRIPTION
When viewing a list of changesets is is very useful to know which changeset contain comments. This PR modifies the icon of the link to a changeset if the changeset is commented.
![image](https://user-images.githubusercontent.com/15147421/34072692-5dd5694c-e28c-11e7-98c3-ae15778237f9.png)
