### PR TITLE
Modified db.py to fix error on installation of plugin

### DIFF
--- a/code_comments/db.py
+++ b/code_comments/db.py
@@ -26,7 +26,7 @@ schema = {
     ],
     'code_comments_subscriptions': Table('code_comments_subscriptions',
                                          key=('id', 'user', 'type', 'path',
-                                              'repos', 'rev'))[
+                                              'rev', 'notify'))[
         Column('id', auto_increment=True),
         Column('user'),
         Column('type'),


### PR DESCRIPTION
This appears to fix an installation issue (#82) that I observed when using Trac 1.2.5. When `trac-admin upgrade` was executed, the upgrade would fail with:

>The upgrade failed. Please fix the issue and try again.
> OperationalError: No such column: repos

I cannot tell further implications of this change, please review.