### PR TITLE
Fix subscription module accessing an invalid URL for REST-API

### DIFF
--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -1,5 +1,48 @@
 var underscore = _.noConflict();
 
+function addSubscriptionButton() {
+	if (jQuery('h1').length == 0) {
+		return;
+	}
+
+	var rev = new URLSearchParams(window.location.search).get('rev') || '';
+
+	var button = jQuery(
+		'<button>',
+		{
+			id: 'subscribe',
+			disabled: true,
+			role: 'button',
+			title: 'Code comment subscriptions require JavaScript to be enabled',
+			class: 'ui-button ui-widget ui-state-default ui-corner-all ui-button-text-icon-primary',
+			'data-base-url': window.location.origin,
+			'data-path': window.location.pathname,
+			'data-rev': rev
+		}
+	);
+
+	button.append(
+		jQuery(
+			'<span>',
+			{
+				class: 'ui-button-icon-primary ui-icon ui-icon-closethick'
+			}
+		)
+	);
+
+	button.append(
+		jQuery(
+			'<span>',
+			{
+				text: 'Subscribe',
+				class: 'ui-button-text'
+			}
+		)
+	);
+
+	jQuery('h1').before(button);
+}
+
 (function($) { $(function() {
 	var _ = window.underscore,
 		jQuery = $;  // just in case something uses jQuery() instead of $()
@@ -372,6 +415,7 @@ var underscore = _.noConflict();
 	});
 
 	window.subscription = new Subscription();
+	addSubscriptionButton()
 	window.subscriptionView = new SubscriptionView({model: subscription});
 	if (subscriptionView.el) {
 		subscription.fetch();

--- a/code_comments/htdocs/code-comments.js
+++ b/code_comments/htdocs/code-comments.js
@@ -328,7 +328,7 @@ var underscore = _.noConflict();
 	});
 
 	window.SubscriptionView = Backbone.View.extend({
-		el: $('button#subscribe'),
+		el: 'button#subscribe',
 
 		initialize: function(){
 			_.bindAll(this, "render");

--- a/code_comments/subscription.py
+++ b/code_comments/subscription.py
@@ -6,11 +6,11 @@ import re
 from trac.admin import IAdminCommandProvider
 from trac.attachment import Attachment, IAttachmentChangeListener
 from trac.core import Component, implements
-from trac.util.html import html as tag
 from trac.versioncontrol import (
     RepositoryManager, NoSuchChangeset, IRepositoryChangeListener)
 from trac.web.api import HTTPNotFound, IRequestHandler, ITemplateStreamFilter
 
+from genshi.builder import tag  # Note that trac.util.html.html is NOT a drop-in replacement. (see #85)
 from genshi.filters import Transformer
 
 from code_comments.api import ICodeCommentChangeListener

--- a/code_comments/subscription.py
+++ b/code_comments/subscription.py
@@ -8,10 +8,7 @@ from trac.attachment import Attachment, IAttachmentChangeListener
 from trac.core import Component, implements
 from trac.versioncontrol import (
     RepositoryManager, NoSuchChangeset, IRepositoryChangeListener)
-from trac.web.api import HTTPNotFound, IRequestHandler, ITemplateStreamFilter
-
-from genshi.builder import tag  # Note that trac.util.html.html is NOT a drop-in replacement. (see #85)
-from genshi.filters import Transformer
+from trac.web.api import HTTPNotFound, IRequestHandler
 
 from code_comments.api import ICodeCommentChangeListener
 from code_comments.comments import Comments
@@ -439,7 +436,7 @@ class SubscriptionListeners(Component):
 
 
 class SubscriptionModule(Component):
-    implements(IRequestHandler, ITemplateStreamFilter)
+    implements(IRequestHandler)
 
     # IRequestHandler methods
 
@@ -458,17 +455,6 @@ class SubscriptionModule(Component):
         elif req.method == 'PUT':
             return self._do_PUT(req)
         return self._do_GET(req)
-
-    # ITemplateStreamFilter methods
-
-    def filter_stream(self, req, method, filename, stream, data):
-        if re.match(r'^/(changeset|browser|attachment/ticket/\d+/.?).*',
-                    req.path_info):
-            filter = Transformer('//h1')
-            button = self._subscription_button(req.path_info,
-                                               req.args.get('rev'))
-            stream |= filter.before(button)
-        return stream
 
     # Internal methods
 
@@ -496,15 +482,3 @@ class SubscriptionModule(Component):
             subscription.update()
         req.send(json.dumps(subscription, cls=SubscriptionJSONEncoder),
                  'application/json')
-
-    def _subscription_button(self, path, rev):
-        """
-        Generates a (disabled) button to connect JavaScript to.
-        """
-        return tag.button(
-            'Subscribe', id_='subscribe', disabled=True,
-            title=('Code comment subscriptions require JavaScript '
-                   'to be enabled'),
-            data_base_url=self.env.project_url or self.env.abs_href(),
-            data_path=path,
-            data_rev=rev)


### PR DESCRIPTION
The subscription REST-API lives under `/subscription`. However the code tried accessing `/undefined/subscriptionundefined`.

```
2023-08-27 14:05:51,762 Trac[main] WARNING: [172.17.0.1]
HTTPNotFound: 404 Trac Error (No node undefined/subscriptionundefined),
<RequestWithSession "GET '/browser/undefined/subscriptionundefined'">,
referrer 'http://127.0.0.1:30443/browser/SomeRepo'
```

The reason is that the base URL is supposed to be encoded in the HTML attribute `data-base-url` and the path in `data-path`. These attribute names can not be used in Python as argument because they contain dashes. So in Python the dashes are replaced by underscores. `genshi.builder.tag` [converts the underscores back to dashes](https://genshi.edgewall.org/browser/trunk/genshi/builder.py#L159) and therefore generates the required attribute names. Its supposed replacement `trac.util.html.html` (which was enabled in fa7cdff4500f3a2a215645d3cd5470833dfca624) does not perform such a conversion thereby generating the wrong HTML attributes leading to the wrong URL in the request.

For the upcoming migration away from Genshi we could consider using the already present `CodeComments` dictionary. It already contains a "path" element, although with a somewhat different content.