### PR TITLE
Fix links to comments on changesets

### DIFF
--- a/code_comments/comment.py
+++ b/code_comments/comment.py
@@ -74,7 +74,7 @@ class Comment(object):
             href = self.req.href.browser(self.path, rev=self.revision,
                                          codecomment=self.id)
         elif self.is_comment_to_changeset:
-            href = self.req.href.changeset(self.revision, codecomment=self.id)
+            href = self.req.href.changeset(self.revision + '/' + self.path, codecomment=self.id)
         elif self.is_comment_to_attachment:
             href = self.req.href('/attachment/ticket/%d/%s'
                                  % (self.attachment_ticket,


### PR DESCRIPTION
HTML-links to comments on changesets are broken, because they don't use the repository name. So they only work in a setup where a default repository is defined and it is the only one receiving comments.
```
2023-08-27 18:24:48,193 Trac[main] WARNING: [172.17.0.1] HTTPInternalServerError:
500 Trac Error (No repository specified and no default repository configured.),
<RequestWithSession "GET '/changeset/1dd1c23fc747af84d63d634d61f3eebd3c9cdb84?codecomment=3'">,
referrer 'http://127.0.0.1:30443/changeset/1dd1c23fc747af84d63d634d61f3eebd3c9cdb84/SomeRepo'
```
(Note the repository name `SomeRepo` in the referrer but it is missing in the request.)

This PR modifies the generation of hyperlinks in a way that the link always contains the repository name.

The mentioned links can be found in the list of code-comments and on top of each comment itself.