### PR TITLE
Minor fixes to the HTML table displaying the list of comments

### DIFF
--- a/code_comments/templates/comments.html
+++ b/code_comments/templates/comments.html
@@ -47,8 +47,8 @@
                 <tr class="${idx % 2 and 'odd' or 'even'}">
                     <td class="check"><input type="checkbox" id="checked-$comment.id" /></td>
                     <td>$comment.id</td>
-                    <th>$comment.author</th>
-                    <th>${comment.formatted_date()}</th>
+                    <td>$comment.author</td>
+                    <td>${comment.formatted_date()}</td>
                     <td>${comment.path_link_tag()}</td>
                     <td>$comment.html</td>
                     <td>${comment.get_ticket_links()}</td>

--- a/code_comments/templates/comments.html
+++ b/code_comments/templates/comments.html
@@ -33,7 +33,7 @@
         </form>
         <table class="listing code-comments">
             <thead>
-                <tr class="tarc-columns">
+                <tr class="trac-columns">
                     <th class="check"><input type="checkbox" /></th>
                     <py:for each="header in sortable_headers">
                         <th class="$header.html_class"><a href="$header.link">$header.name</a></th>

--- a/code_comments/web.py
+++ b/code_comments/web.py
@@ -242,7 +242,7 @@ class ListComments(CodeComments):
         displayed_sorting_methods = \
             ('id', 'author', 'time', 'path', 'text')
         displayed_sorting_method_names = \
-            ('ID', 'Author', 'Date', 'Path', 'Text')
+            ('ID', 'Author', 'Timestamp', 'Path', 'Text')
         query_args = self.req.args
         if 'page' in query_args:
             del query_args['page']


### PR DESCRIPTION
- Use correct CSS class `trac-table` (there was a typo)
- Change column name from _Date_ to _Timestamp_ (the column contains timestamps not just dates)
- Avoid highlighting the _Author_ and _Timestamp_ column (they used `<th>` instead of `<td>` for the values)